### PR TITLE
Add AGENTS.md and update mod list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS.md — Tambay Zomboid Server
+
+## What this is
+
+Docker containerization of a Project Zomboid dedicated server (build 42 unstable/beta).  
+Infrastructure project — pure Docker + Shell + Lua. No Node.js, no npm, no web framework.
+
+## Active branch
+
+Work on `feat/pz-mods-06082026`, not `main`.  
+`main` is release branch — pushes trigger Docker Hub deploy via CI.
+
+## Commands
+
+```bash
+build.bat                    # Windows: docker build (copies .env.example → .env if missing)
+start.bat                    # Windows: docker run (BUG: STEAM_USER set twice, not STEAM_PASSWORD)
+docker compose build         # Build via Compose
+docker compose up -d         # Run via Compose (background)
+```
+
+CI (GitHub Actions):
+- PR → `main`: builds (docker-image.yml, no push)
+- Push → `main`: builds + pushes to `rhonstratos/tambay_zomboid:latest` (deploy-to-dockerhub.yml)
+
+No tests, lint, or typecheck. Validation: build → container starts → server responds on UDP 8766/16261/16262.
+
+## Setup
+
+Copy `.env.example` → `.env`, fill in:
+
+| Var | Required | Note |
+|---|---|---|
+| `ADMIN_PASSWORD` | Yes | Passed to `start-server.sh`; server won't start without it |
+| `STEAM_USER` / `STEAM_PASSWORD` | For unstable | Needed for build 42 beta; falls back to anonymous stable |
+| `SERVER_NAME` | No | Default `tambay_server` in Dockerfile |
+| `TZ` | No | Default `Asia/Manila` |
+
+## Quirks & gotchas
+
+- **`docker-compose.yaml`** uses `network_mode: host`. Port mappings ignored through Compose — container shares host network stack directly.
+- **`docker-compose.yaml`** references `rhonstratos/tambay_zomboid:latest` from Docker Hub, not a local build.
+- **`start.bat` bug**: line 17 sets `STEAM_USER` again instead of `STEAM_PASSWORD` — copy-paste error.
+- **Server name is baked into filenames**: `tambay_server.ini`, `tambay_server_SandboxVars.lua`, etc. Changing `SERVER_NAME` breaks config mapping unless files are renamed.
+- **`Zomboid/Server/.gitignore`** only has `!tambay_server**` — the preceding `*` line is missing. Only `tambay_server*` files are intended to be tracked; other Server dir contents are ignored.
+- **Build installs PZ during Docker build** (anonymous stable) AND entrypoint re-checks at runtime. Entrypoint installs/updates if `start-server.sh` missing or `FORCE_UPDATE=true`. Update branch needs `STEAM_USER`/`STEAM_PASSWORD` at runtime.
+- **entrypoint.sh** (`/home/pzuser/entrypoint.sh`): creates `Zomboid/{Server,db,backups,Workshop,Mods}` via `sudo mkdir` + `chown`. Runs as `pzuser` (limited sudo: only `mkdir`/`chown`).
+- **SteamCMD** at `/steamcmd`, server at `/pzserver` — both image layers (not volumes).
+- **Anti-cheat**: All disabled (Safety, Movement, Hit, Packet, Permission, XP, SafeHouse, Player, Checksum, Item). Intentional for PvP/mods.
+- **XP multiplier**: 30×. Skill journal on (24h play min, 24h save cooldown, 1-level death penalty, profession lock).
+- **Mods**: ~30 Workshop + ~31 in-game. Mod list in `tambay_server.ini` lines 67 (`Mods=`) and 210 (`WorkshopItems=`). Heavily uses CommonSenseReborn.
+- **Deployment**: Remote CentOS/CasaOS behind Tailscale. Docker Hub push from `main`.
+
+## Config surface
+
+| File | Role |
+|---|---|
+| `Zomboid/Server/tambay_server.ini` | Main server config (416 lines) |
+| `Zomboid/Server/tambay_server_SandboxVars.lua` | Gameplay/sandbox vars (2065 lines) |
+| `Zomboid/Server/tambay_server_spawnpoints.lua` | Spawn points |
+| `Zomboid/Server/tambay_server_spawnregions.lua` | Spawn regions |
+| `Zomboid/Assets/Images/` | Custom in-game images (splash, overlay, poggy.png) |
+| `entrypoint.sh` | Runtime entrypoint: dirs → install/update → launch |
+| `.env.example` | Template — copy to `.env` and fill |

--- a/Zomboid/Server/tambay_server.ini
+++ b/Zomboid/Server/tambay_server.ini
@@ -64,7 +64,7 @@ UDPPort=16262
 ResetID=6275294
 
 # Enter the mod loading ID here. It can be found in \Steam\steamapps\workshop\modID\mods\modName\info.txt
-Mods=NeatUI_Framework;CleanHotBar;CleanUI;ClientModsToServer;FRCB42;HideDebugMenu;MiniHealthPanel;ModLoadOrderSorter_b42;ChuckleberryFinnAlertSystem;ModManager;REORDER_THE_HOTBAR;errorMagnifier;UseItemsWhileWalkingB42;BetterFlashlightsFixed;MoreDamagedObjects;OccupationStartingItems;RiskyInspectWeapon;CleansingRain;CommonSenseReborn;BookstoreStorageFix;firearmmod;MinimalSidebar;ISyncYouSyncWeAllSyncForDeSync;hf_point_blank;ProximityInventory;Tempo_PerfKit;WashFix;UndeadSurvivor42
+Mods=NeatUI_Framework;CleanHotBar;CleanUI;ClientModsToServer;FRCB42;HideDebugMenu;MiniHealthPanel;ModLoadOrderSorter_b42;ChuckleberryFinnAlertSystem;ModManager;REORDER_THE_HOTBAR;errorMagnifier;UseItemsWhileWalkingB42;BetterFlashlightsFixed;MoreDamagedObjects;OccupationStartingItems;RiskyInspectWeapon;CleansingRain;CommonSenseReborn;BookstoreStorageFix;firearmmod;MinimalSidebar;ISyncYouSyncWeAllSyncForDeSync;hf_point_blank;ProximityInventory;Tempo_PerfKit;WashFix;UndeadSurvivor42;LNB42;BicycleMod
 
 # Enter the foldername of the mod found in \Steam\steamapps\workshop\modID\mods\modName\media\maps\
 Map=Muldraugh, KY
@@ -207,7 +207,7 @@ SneakModeHideFromOtherPlayers=true
 UltraSpeedDoesnotAffectToAnimals=false
 
 # List Workshop Mod IDs for the server to download. Each must be separated by a semicolon. Example: WorkshopItems=514427485;513111049
-WorkshopItems=3508537032;3461263912;3437629766;2756434288;3414409419;3554048011;2866258937;3423660713;3077900375;3567084868;3663625294;2896041179;3615422211;3420478458;3413150945;3414144747;2948824747;3723749278;3698958906;3734168173;2256623447;3642084851;3705645576;2990322197;3669550831;3736629791;3460812542;3739427877
+WorkshopItems=3508537032;3461263912;3437629766;2756434288;3414409419;3554048011;2866258937;3423660713;3077900375;3567084868;3663625294;2896041179;3615422211;3420478458;3413150945;3414144747;2948824747;3723749278;3698958906;3734168173;2256623447;3642084851;3705645576;2990322197;3669550831;3736629791;3460812542;3739427877;3580577925;3461415167
 
 # Show Steam usernames and avatars in the Players list.
 SteamScoreboard=false


### PR DESCRIPTION
## Changes

- **`AGENTS.md`** — New compact instruction file for future OpenCode sessions. Covers active branch, commands, setup, quirks, gotchas, and config surface. Replaces the previously missing/unversioned agent guidance with verified, repo-specific facts.
- **`Zomboid/Server/tambay_server.ini`** — Adds `LNB42` and `BicycleMod` to the `Mods` list and two workshop items (`3580577925`, `3461415167`) to the `WorkshopItems` list.

## Verification

- [x] Docker build succeeds
- [x] Container starts and responds on UDP ports 8766/16261/16262